### PR TITLE
Discard master/slave terminology

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/libcontainer/netlink/netlink_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/libcontainer/netlink/netlink_linux.go
@@ -548,8 +548,8 @@ func NetworkSetMTU(iface *net.Interface, mtu int) error {
 	return s.HandleAck(wb.Seq)
 }
 
-// same as ip link set $name master $master
-func NetworkSetMaster(iface, master *net.Interface) error {
+// same as ip link set $name main $main
+func NetworkSetMain(iface, main *net.Interface) error {
 	s, err := getNetlinkSocket()
 	if err != nil {
 		return err
@@ -569,7 +569,7 @@ func NetworkSetMaster(iface, master *net.Interface) error {
 		b      = make([]byte, 4)
 		native = nativeEndian()
 	)
-	native.PutUint32(b, uint32(master.Index))
+	native.PutUint32(b, uint32(main.Index))
 
 	data := newRtAttr(syscall.IFLA_MASTER, b)
 	wb.AddData(data)
@@ -950,11 +950,11 @@ func DeleteBridge(name string) error {
 	return nil
 }
 
-// Add a slave to abridge device.  This is more backward-compatible than
-// netlink.NetworkSetMaster and works on RHEL 6.
-func AddToBridge(iface, master *net.Interface) error {
-	if len(master.Name) >= IFNAMSIZ {
-		return fmt.Errorf("Interface name %s too long", master.Name)
+// Add a subordinate to abridge device.  This is more backward-compatible than
+// netlink.NetworkSetMain and works on RHEL 6.
+func AddToBridge(iface, main *net.Interface) error {
+	if len(main.Name) >= IFNAMSIZ {
+		return fmt.Errorf("Interface name %s too long", main.Name)
 	}
 
 	s, err := getIfSocket()
@@ -964,7 +964,7 @@ func AddToBridge(iface, master *net.Interface) error {
 	defer syscall.Close(s)
 
 	ifr := ifreqIndex{}
-	copy(ifr.IfrnName[:len(ifr.IfrnName)-1], master.Name)
+	copy(ifr.IfrnName[:len(ifr.IfrnName)-1], main.Name)
 	ifr.IfruIndex = int32(iface.Index)
 
 	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(s), SIOC_BRADDIF, uintptr(unsafe.Pointer(&ifr))); err != 0 {

--- a/Godeps/_workspace/src/github.com/docker/libcontainer/netlink/netlink_unsupported.go
+++ b/Godeps/_workspace/src/github.com/docker/libcontainer/netlink/netlink_unsupported.go
@@ -55,7 +55,7 @@ func NetworkSetNsPid(iface *net.Interface, nspid int) error {
 	return ErrNotImplemented
 }
 
-func NetworkSetMaster(iface, master *net.Interface) error {
+func NetworkSetMain(iface, main *net.Interface) error {
 	return ErrNotImplemented
 }
 
@@ -71,6 +71,6 @@ func DeleteBridge(name string) error {
 	return ErrNotImplemented
 }
 
-func AddToBridge(iface, master *net.Interface) error {
+func AddToBridge(iface, main *net.Interface) error {
 	return ErrNotImplemented
 }

--- a/controller/service_manager.go
+++ b/controller/service_manager.go
@@ -173,6 +173,6 @@ func (mgr *ServiceManager) Schedule() {
 	}
 }
 
-// ServeNode would run the actuall service on all the slave nodes
+// ServeNode would run the actuall service on all the subordinate nodes
 func (mgr *ServiceManager) ServeNode(node string) {
 }


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.